### PR TITLE
Continue added to counter space before comand's 'Error'

### DIFF
--- a/PersonalShell.c
+++ b/PersonalShell.c
@@ -156,7 +156,10 @@ int parseSpace(char* str, char** parsed)
         if (parsed[i] == NULL) 
             break; 
         if (strlen(parsed[i]) == 0) 
-            i--;
+	{
+		i--;
+		continue;
+	}
        count++;	
     }
    return count; 


### PR DESCRIPTION
Space error before command in shell cured.
ex: 
$:    ls > p.txt 
would give an error
